### PR TITLE
Updated to work in latest iPad Swift Playgrounds

### DIFF
--- a/Guilloche.playgroundbook/Contents/Chapters/GuillochePatterns.playgroundchapter/Pages/Experiment.playgroundpage/Contents.swift
+++ b/Guilloche.playgroundbook/Contents/Chapters/GuillochePatterns.playgroundchapter/Pages/Experiment.playgroundpage/Contents.swift
@@ -11,7 +11,7 @@ import SpriteKit
 // Hacks because playground hates applyWithBlock even on iOS 11
 extension CGPath {
     
-    func forEach( body: @convention(block) (CGPathElement) -> Void) {
+    func forEach( body: @escaping @convention(block) (CGPathElement) -> Void) {
         typealias Body = @convention(block) (CGPathElement) -> Void
         let callback: @convention(c) (UnsafeMutableRawPointer, UnsafePointer<CGPathElement>) -> Void = { (info, element) in
             let body = unsafeBitCast(info, to: Body.self)

--- a/Guilloche.playgroundbook/Contents/Chapters/GuillochePatterns.playgroundchapter/Pages/Guilloche.playgroundpage/Contents.swift
+++ b/Guilloche.playgroundbook/Contents/Chapters/GuillochePatterns.playgroundchapter/Pages/Guilloche.playgroundpage/Contents.swift
@@ -12,7 +12,7 @@ import SpriteKit
 // Hacks because playground hates applyWithBlock even on iOS 11
 extension CGPath {
     
-    func forEach( body: @convention(block) (CGPathElement) -> Void) {
+    func forEach( body: @escaping @convention(block) (CGPathElement) -> Void) {
         typealias Body = @convention(block) (CGPathElement) -> Void
         let callback: @convention(c) (UnsafeMutableRawPointer, UnsafePointer<CGPathElement>) -> Void = { (info, element) in
             let body = unsafeBitCast(info, to: Body.self)


### PR DESCRIPTION
Addressed a minor compile error that prevents execution in the latest Swift Playgrounds.